### PR TITLE
Fix download URL for vega spectrum

### DIFF
--- a/notebooks/figures/sdss_filters.py
+++ b/notebooks/figures/sdss_filters.py
@@ -14,7 +14,7 @@ from matplotlib.patches import Arrow
 
 DOWNLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'downloads')
-REFSPEC_URL = 'ftp://ftp.stsci.edu/cdbs/current_calspec/1732526_nic_002.ascii'
+REFSPEC_URL = 'ftp://ftp.stsci.edu/cdbs/current_calspec/ascii_files/1732526_nic_002.ascii'
 FILTER_URL = 'http://www.sdss.org/dr7/instruments/imager/filters/%s.dat'
 
 def fetch_filter(filt):


### PR DESCRIPTION
It seems that the ASCII file of the Vega spectrum has been moved to a subdirectory 'ascii_files' of the directory the current URL points to.
I updated the appropriate constant and the files are downloading fine now.
