### PR TITLE
Fix download URL for vega spectrum and URL for SDSS database

### DIFF
--- a/notebooks/datasets/galaxy_mags.py
+++ b/notebooks/datasets/galaxy_mags.py
@@ -5,7 +5,7 @@ import numpy as np
 
 #----------------------------------------------------------------------
 # Tools for querying the SDSS database using SQL
-PUBLIC_URL = 'http://cas.sdss.org/public/en/tools/search/x_sql.asp'
+PUBLIC_URL = 'http://skyserver.sdss.org/dr7/en/tools/search/x_sql.asp'
 DEFAULT_FMT = 'csv'
 
 

--- a/notebooks/figures/sdss_filters.py
+++ b/notebooks/figures/sdss_filters.py
@@ -14,7 +14,7 @@ from matplotlib.patches import Arrow
 
 DOWNLOAD_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             'downloads')
-REFSPEC_URL = 'ftp://ftp.stsci.edu/cdbs/current_calspec/ascii_files/1732526_nic_002.ascii'
+REFSPEC_URL = 'http://www.astro.washington.edu/users/ivezic/DMbook/data/1732526_nic_002.ascii'
 FILTER_URL = 'http://www.sdss.org/dr7/instruments/imager/filters/%s.dat'
 
 def fetch_filter(filt):


### PR DESCRIPTION
I updated the vega spectrum url and sdss database url. These urls were broken.
Now download_data.py works properly.
